### PR TITLE
feat: Add Docker Compose setup for containerized development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Use a more specific Python 3.11 slim image, aligning with your local environment
+FROM python:3.11-slim
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Copy requirements first to leverage Docker cache
+# This layer will only be rebuilt if requirements.txt changes
+COPY requirements.txt .
+
+# Install dependencies with --no-cache-dir for smaller image size
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy all application code into the container
+# NOTE: This copies files from your build context. Use .dockerignore to exclude
+# large or unnecessary files (like .git, venv/, mlruns/, data/).
+# For development with docker-compose volumes, this COPY is less critical for source code
+# (as the volume mount overwrites it), but it's good practice for general image builds.
+COPY . .
+
+# Expose the port your FastAPI application listens on
+EXPOSE 8000
+
+# Command to run the application using uvicorn
+# --host 0.0.0.0 is crucial for allowing external connections to the container
+CMD ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.8' # Good version, supports current Docker Compose features
+
+services:
+  web:
+    build: . # Builds the image using the Dockerfile in the current directory
+    ports:
+      - "8000:8000" # Maps host port 8000 to container port 8000 for your FastAPI app
+    volumes:
+      # Mounts the current directory (your project root) into /app inside the container.
+      # This is excellent for development as changes on your host machine
+      # are immediately reflected in the container due to Uvicorn's --reload.
+      # It effectively overlays/overrides the `COPY . .` instruction for source code.
+      # Ensure you have a .dockerignore file to prevent unnecessary files from being
+      # copied into the image initially, even if they are later mounted.
+      - .:/app
+    environment:
+      # Crucial: Tells your FastAPI app (inside the 'web' container) how to connect to the MLflow server.
+      # 'mlflow' here is the service name defined below in this docker-compose file.
+      - MLFLOW_TRACKING_URI=http://mlflow:5000
+    depends_on:
+      # Ensures the 'mlflow' service starts successfully before 'web' attempts to start.
+      - mlflow
+
+  mlflow:
+    image: mlflow/mlflow # Uses the official MLflow Docker image
+    ports:
+      - "5000:5000" # Maps host port 5000 to container port 5000 for MLflow UI
+    volumes:
+      # Mounts your local 'mlruns' directory to '/mlruns' inside the container.
+      # This is vital for persisting your MLflow experiments and models on your host machine,
+      # so data isn't lost when the container is removed/restarted.
+      - ./mlruns:/mlruns
+    command: > # Multi-line command for starting the MLflow server
+      mlflow server
+      --backend-store-uri file:///mlruns # Tells MLflow to store data in the mounted volume
+      --default-artifact-root file:///mlruns # Tells MLflow to store artifacts in the mounted volume
+      --host 0.0.0.0 # Allows external connections to the MLflow UI inside the container


### PR DESCRIPTION
Sets up a multi-service Docker environment using docker-compose.yml and Dockerfile:
- **`Dockerfile`**: Defines the application image, using Python 3.11-slim and copying dependencies.
- **`docker-compose.yml`**: Orchestrates the 'web' service (FastAPI application) and 'mlflow' service (MLflow tracking server).
- Configures volume mounts for persisting MLflow data and enables live code changes during development.
- Sets `MLFLOW_TRACKING_URI` environment variable for seamless integration between services.
- Includes `.dockerignore` for leaner image builds by excluding unnecessary files.